### PR TITLE
A simple way to use Mathetes on servers other than Freenode

### DIFF
--- a/irc-bot.rb
+++ b/irc-bot.rb
@@ -24,21 +24,23 @@ end
 module Mathetes
   class IRCBot
     def initialize
+      @conf = YAML.load_file 'mathetes-config.yaml'
       @irc = SilverPlatter::IRC::Connection.new(
-        "irc.freenode.net",
+        @conf[ 'server' ],
         :log => SilverPlatter::Log.to_console( :formatter => SilverPlatter::Log::ColoredDebugConsole )
       )
-      reset
+      # Don't reload the config here: we just did that four lines up
+      reset(false)
       puts "Initialized."
     end
 
-    def reset
+    def reset(conf = true)
       puts "Resetting..."
 
       kill_threads
       unsubscribe_listeners
       parted = part_channels
-      @conf = YAML.load_file 'mathetes-config.yaml'
+      @conf = YAML.load_file 'mathetes-config.yaml' if conf
       initialize_hooks
       initialize_plugins
       join_channels parted

--- a/mathetes-config.yaml.sample
+++ b/mathetes-config.yaml.sample
@@ -1,4 +1,5 @@
 ---
+server: irc.freenode.net
 nick: YourBotsNick
 password: 'thesecretpassword'
 channels:


### PR DESCRIPTION
I moved the initial loading of `@conf` into `initialize` so that the server value could be read from the yaml configuration. (In order to make this a little cleaner, I also tweaked reset slightly so that it would reload `@conf` immediately after it was first loaded.)
